### PR TITLE
Relax bounds for reflex-basic-host-0.2

### DIFF
--- a/nix/reflex-basic-host.json
+++ b/nix/reflex-basic-host.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/reflex-basic-host",
-  "rev": "22fa91611f1eb8ef2f1cc4aeb7c52484a4c75dc5",
-  "date": "2019-03-18T10:37:31+10:00",
-  "sha256": "03zgphm0dib5nizxbzakb02561r3wsdlj91zh2x6b853dpdgcc1y",
+  "rev": "d989d43fb920477f033dffe50f896eeacbccefac",
+  "date": "2019-06-27T22:07:39+10:00",
+  "sha256": "0dak3hbd3hhaa8lc0a43va41lkmjn3ffk98zp5blp3ajh3ijx2b6",
   "fetchSubmodules": false
 }

--- a/nix/reflex-basic-host.nix
+++ b/nix/reflex-basic-host.nix
@@ -4,7 +4,7 @@ let
   sources = rec {
     reflex-basic-host-info-pinned = initialNixpkgs.pkgs.lib.importJSON ./reflex-basic-host.json;
     reflex-basic-host = initialNixpkgs.pkgs.fetchFromGitHub {
-      owner = "dalaing";
+      owner = "qpfl";
       repo = "reflex-basic-host";
       inherit (reflex-basic-host-info-pinned) rev sha256;
     };

--- a/nix/reflex-platform.json
+++ b/nix/reflex-platform.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/reflex-frp/reflex-platform",
-  "rev": "465d4ce91255790046fe5d4e625bc1eacd324d00",
-  "date": "2019-03-17T20:42:43-04:00",
-  "sha256": "0d043rv7adv86kr3dmazn3brkpg4dh4xixjiimr7zxhas36bxizr",
+  "rev": "716879f16d53c93766e7ed9af17416fccb2edfe1",
+  "date": "2019-06-15T14:12:13-04:00",
+  "sha256": "1mngxa24cfpvxxq4hgh77nw36vny4abl5wi2xmlwpkk25wzm0h0x",
   "fetchSubmodules": false
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-prefetch-git
 
 nix-prefetch-git https://github.com/reflex-frp/reflex-platform > reflex-platform.json
 nix-prefetch-git https://github.com/qfpl/reflex-basic-host > reflex-basic-host.json

--- a/reflex-backend-wai.cabal
+++ b/reflex-backend-wai.cabal
@@ -8,12 +8,12 @@ description:
   .
   > {-# LANGUAGE OverloadedStrings #-}
   > module Main where
-  >  
+  >
   > import Network.Wai (responseLBS)
   > import Network.HTTP.Types.Status (status200)
-  >  
+  >
   > import Reflex.Backend.Warp (runAppForever)
-  >  
+  >
   > main :: IO ()
   > main =
   >   runAppForever 8080 $ \eReq -> do
@@ -24,7 +24,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Dave Laing
 maintainer:          dave.laing.80@gmail.com
--- copyright:           
+-- copyright:
 category:            FRP, Web
 build-type:          Simple
 extra-source-files:  ChangeLog.md
@@ -45,7 +45,7 @@ library
                      , containers >= 0.5   && < 0.7
                      , mtl        >= 2.2.1 && < 2.3
                      , reflex     >= 0.5   && < 0.7
-                     , reflex-basic-host >= 0.1 && < 0.2
+                     , reflex-basic-host >= 0.1 && < 0.3
                      , stm        >= 2.4.4 && < 2.6
                      , wai        >= 3.2.1 && < 3.3
                      , warp >= 3.2.13 && < 3.3
@@ -63,4 +63,3 @@ executable example
   hs-source-dirs:      exe
   ghc-options:         -Wall
   default-language:    Haskell2010
-  


### PR DESCRIPTION
Do not merge until after qfpl/reflex-basic-host#7 is merged. Needs an update of reflex-basic-host.json also.